### PR TITLE
Add labels

### DIFF
--- a/collector/chassis_collector.go
+++ b/collector/chassis_collector.go
@@ -392,8 +392,6 @@ func parseChassisPowerInfoVoltage(ch chan<- prometheus.Metric, chassisID string,
 		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_power_voltage_state"].desc, prometheus.GaugeValue, chassisPowerInfoVoltageStateValue, chassisPowerVoltageLabelvalues...)
 	}
 	ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_power_voltage_volts"].desc, prometheus.GaugeValue, float64(chassisPowerInfoVoltageNameReadingVolts), chassisPowerVoltageLabelvalues...)
-
-	fmt.Printf("%+v - %+v\n", chassisPowerInfoVoltage.Name, chassisPowerInfoVoltage.ReadingVolts)
 }
 func parseChassisPowerInfoPowerControl(ch chan<- prometheus.Metric, chassisID string, chassisPowerInfoPowerControl redfish.PowerControl, wg *sync.WaitGroup) {
 	defer wg.Done()


### PR DESCRIPTION
- Add more labels for systems and drives. These labels are useful for alerting and ticket creation. 
- Additional metric for drive failure detection